### PR TITLE
Modified mysqlTransformer to filter away mock processes from buildup. Altered configuration example for camunda

### DIFF
--- a/conf/example/camunda.data-transformers.yml
+++ b/conf/example/camunda.data-transformers.yml
@@ -6,3 +6,6 @@ settings:
         PROC_INST_ID_: "process_instance_id"
         START_TIME_: "start_time"
         END_TIME_: "end_time"
+        PROC_DEF_ID_: "process_definition_id"
+        PROC_INST_ID_: "source_process_instance_id"
+limit_process_string_id: "mock"


### PR DESCRIPTION
- MysqlTransformer now searches for a provided substring ("mock" in our example) in the database rows, and filters away all processes containing that substring, to skip the buildup phase of the wfms when transforming the data.
- Altered configuration example to include the mock string, and complete the column transformations for camunda
