### PR TITLE
Fixed issue when custom stats are not defined in Faban

### DIFF
--- a/data-transformers/transformers/fabanTransformer.py
+++ b/data-transformers/transformers/fabanTransformer.py
@@ -105,6 +105,8 @@ def createDriverDelayTimesQuery(data, trialID, experimentID, host):
 def createDriverCustomStatsQuery(data, trialID, experimentID, host):
     queries = []
     for driver in data.findall("driverSummary"):
+        if driver.find("customStats") is None:
+            return queries
         for stat in driver.find("customStats"):
             query = {}
             query["trial_id"] = trialID
@@ -231,8 +233,9 @@ def main():
                 
             def fF():
                 query = createDriverCustomStatsQuery(dataXML, trialID, experimentID, host)
-                query = sc.parallelize(query)
-                query.saveToCassandra(cassandraKeyspace, "faban_driver_custom_stats")
+                if len(query) != 0:
+                    query = sc.parallelize(query)
+                    query.saveToCassandra(cassandraKeyspace, "faban_driver_custom_stats")
                 
             tA = threading.Thread(target=fA)
             tB = threading.Thread(target=fB)


### PR DESCRIPTION
It’s possible that custom stats are not present in Faban. Fixed a crash in that case.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/benchflow/data-transformers/pull/88?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benchflow/data-transformers/pull/88'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
