### PR TITLE
Quick fix for possible missing Name in restart policy for properties

### DIFF
--- a/data-transformers/transformers/propertiesTransformer.py
+++ b/data-transformers/transformers/propertiesTransformer.py
@@ -62,7 +62,7 @@ def createContainerDict(a, trialID, experimentID, containerID, hostID):
         d["privileged"] = ob["HostConfig"]["Privileged"]
     if "ReadonlyRootfs" in ob["HostConfig"].keys():
         d["read_only"] = ob["HostConfig"]["ReadonlyRootfs"]
-    if "RestartPolicy" in ob["HostConfig"].keys():
+    if "RestartPolicy" in ob["HostConfig"].keys() and "Name" in ob["HostConfig"]["RestartPolicy"]:
         d["restart_policy"] = ob["HostConfig"]["RestartPolicy"]["Name"]
     if "Name" in ob.keys():
         d["name"] = ob["Name"].replace("/", "")


### PR DESCRIPTION
Fix for a missing check for the name entry for restart policy in the container properties.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/benchflow/data-transformers/pull/89?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benchflow/data-transformers/pull/89'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
