### PR TITLE
Fix network stats with nethogs to take the right PID for tops comparison

### DIFF
--- a/data-transformers/transformers/statsTransformer.py
+++ b/data-transformers/transformers/statsTransformer.py
@@ -151,7 +151,7 @@ def createNetworkHostQuery(sc, top, net, trialID, experimentID, containerID, hos
         data = json.loads(a.decode())
         pids = []
         for p in data["Processes"]:
-            pids.append(p[2])
+            pids.append(p[1])
         return pids
     PIDS = sc.parallelize(top).map(getPid).reduce(lambda a, b: a+b)
     


### PR DESCRIPTION
Should prevent the issue with network interface data being 0 when using net=host, see https://github.com/benchflow/data-transformers/issues/93

<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/benchflow/data-transformers/pull/94?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benchflow/data-transformers/pull/94'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
